### PR TITLE
reload munge service when munge key have been change

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -3,6 +3,11 @@
   systemd:
     daemon_reload: yes
 
+- name: restart munge
+  service:
+    name: munge
+    state: restarted
+
 - name: reload slurmd
   service:
     name: "{{ slurmd_service_name }}"

--- a/tasks/munge.yml
+++ b/tasks/munge.yml
@@ -16,6 +16,7 @@
     group: munge
     mode: 0400
   when: slurm_munge_key is defined
+  notify: restart munge
 
 - name: Ensure Munge is enabled and running
   service:


### PR DESCRIPTION
Note : service munge must be restarted before slurm service so ordre in handlers/main.yml is important